### PR TITLE
calculate value of user's lp tokens for usdt pool

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "@uniswap/sdk-core": "^4.0.10",
         "@uniswap/v2-sdk": "^4.1.0",
+        "dotenv": "^16.4.1",
         "ethers": "^6.10.0",
         "node-fetch": "^3.3.2",
         "react": "^18.2.0",
@@ -7310,11 +7311,14 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
+      "integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/dotenv-expand": {
@@ -15251,6 +15255,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/read-cache": {
@@ -23492,9 +23504,9 @@
       }
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
+      "integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ=="
     },
     "dotenv-expand": {
       "version": "5.1.0",
@@ -29028,6 +29040,13 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        }
       }
     },
     "read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "@uniswap/sdk-core": "^4.0.10",
     "@uniswap/v2-sdk": "^4.1.0",
+    "dotenv": "^16.4.1",
     "ethers": "^6.10.0",
     "node-fetch": "^3.3.2",
     "react": "^18.2.0",

--- a/frontend/src/components/DeFi.jsx
+++ b/frontend/src/components/DeFi.jsx
@@ -4,11 +4,6 @@ const DeFi = () => {
   return (
     <div className="">
       <LpPoolCard />
-      <LpPoolCard />
-      <LpPoolCard />
-      <LpPoolCard />
-      <LpPoolCard />
-      <LpPoolCard />
     </div>
   );
 };

--- a/frontend/src/components/LpPoolCard.jsx
+++ b/frontend/src/components/LpPoolCard.jsx
@@ -6,6 +6,11 @@ const LPPoolCard = () => {
   const [LPTokenAmount, setLPTokenAmount] = useState();
   const [PairAddress, setPairAddress] = useState();
 
+  const [userLpTokenValue, setUserLpTokenValue] = useState();
+  const [totalLpTokenAmount, setTotalLpTokenAmount] = useState();
+  const [usdtAddress, setUsdtAddress] = useState();
+  const [usdtAmountInLpContract, setUsdtAmountInLpContract] = useState();
+
   useEffect(() => {
     async function getLPTokens() {
       try {
@@ -17,11 +22,14 @@ const LPPoolCard = () => {
 
         // WETH-USDT Pair LP Token Contract
         // CA: 0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852
+
+        //사용자가 보유한 LP 토큰 개수
         const token_url = `https://api.etherscan.io/api?module=account&action=tokenbalance&contractaddress=${pairAddress}&address=${testAccount}&tag=latest&apikey=${etherscanKey}`;
         const token_response = await fetch(token_url);
         const token = await token_response.json();
         setLPTokenAmount(ethers.formatEther(token.result));
 
+        //LP Contract의 심볼 불러오기
         const contract_url = `https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${pairAddress}&apikey=${etherscanKey}`;
         const contract_response = await fetch(contract_url);
         const { result } = await contract_response.json();
@@ -35,6 +43,29 @@ const LPPoolCard = () => {
         );
         const contract_symbol = await contract.symbol();
         setLPTokenName(contract_symbol);
+
+        // 아래 추가된 부분은 사용자가 보유한 LP 토큰의 달러 가치 계산하기
+
+        //1. LP Contract에 있는 전체 USDT 개수 구하기 (LP의 TVL = 2 * 전체 USDT 개수)
+        const usdtAddress = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+        setUsdtAddress(usdtAddress);
+        const usdt_url = `https://api.etherscan.io/api?module=account&action=tokenbalance&contractaddress=${usdtAddress}&address=${pairAddress}&tag=latest&apikey=${etherscanKey}`;
+        const usdt_response = await fetch(usdt_url);
+        console.log(usdt_url);
+        const usdt = await usdt_response.json();
+        setUsdtAmountInLpContract(usdt.result / 10 ** 6);
+
+        //2. LP Contract에서 발행된 전체 LP 토큰 개수
+        const totalLpTokenSupply_url = `https://api.etherscan.io/api?module=stats&action=tokensupply&contractaddress=${pairAddress}&apikey=${etherscanKey}`;
+        const totalLpTokenSupply_response = await fetch(totalLpTokenSupply_url);
+        const totalLpTokenSupply = await totalLpTokenSupply_response.json();
+        setTotalLpTokenAmount(ethers.formatEther(totalLpTokenSupply.result));
+
+        //2. 사용자가 보유한 LP 토큰 개수가 가진 달러 가치 (TVL / 전체 LP 개수) * 사용자가 보유한 LP 개수
+        // LP 토큰 1개 가격 = (TVL / 전체 LP 개수)
+        setUserLpTokenValue(
+          LPTokenAmount * ((2 * usdtAmountInLpContract) / totalLpTokenAmount)
+        );
       } catch (error) {
         console.log(error);
       }
@@ -65,7 +96,7 @@ const LPPoolCard = () => {
         </div>
         <div className="flex flex-col gap-2">
           <div>USD</div>
-          <div>$TBD</div>
+          <div>{userLpTokenValue.toFixed(2)}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 개요

LpPoolCard 에서 사용자가 보유한 LP 토큰의 달러 가치 계산값을 추가했습니다. 

## 변경사항에 대한 설명
현재의 수식은 A-B 토큰으로 구성된 여러 유동성 풀 중에서 WETH-USDT 처럼 하나의 토큰이 USDT인 경우에 대해서만 적용됩니다. 추후 USDT가 아닌 USDC 등 다른 스테이블코인 및 스테이블코인이 없는 풀에 대한 계산으로 확장이 필요합니다. 

## 팀 공유 및 요청 사항
