### PR TITLE
uniswap v3 link added, tofixed(4)

### DIFF
--- a/frontend/src/components/LpPoolCard.jsx
+++ b/frontend/src/components/LpPoolCard.jsx
@@ -400,7 +400,7 @@ const LPPoolCard = ({
               <div className="text-green-500">{`+%${(
                 (apy * apyConstant) /
                 365
-              ).toFixed(2)}`}</div>
+              ).toFixed(4)}`}</div>
               {/* 수익률 기간토글 */}
               <div className="flex flex-row gap-1 items-center text-xs ">
                 <div className="flex flex-row justify-evenly rounded-md border border-purple-950 divide-x divide-purple-950">
@@ -460,11 +460,11 @@ const LPPoolCard = ({
             <div className="dm-sans-defi-info-light flex flex-row justify-between items-center mx-4">
               <div className="flex flex-col justify-center">
                 <div>
-                  {(reserve0 * (LPTokenAmount / totalLpSupply)).toFixed(6)}{" "}
+                  {(reserve0 * (LPTokenAmount / totalLpSupply)).toFixed(4)}{" "}
                   {symbol0}
                 </div>
                 <div className="m-sans-body-reveal">
-                  {(reserve1 * (LPTokenAmount / totalLpSupply)).toFixed(6)}{" "}
+                  {(reserve1 * (LPTokenAmount / totalLpSupply)).toFixed(4)}{" "}
                   {symbol1}
                 </div>
               </div>

--- a/frontend/src/components/LpPoolCardUniswapV3.jsx
+++ b/frontend/src/components/LpPoolCardUniswapV3.jsx
@@ -663,8 +663,14 @@ const LpPoolCardUniswapV3 = ({
             {/* 카드이름 */}
             <div className="flex flex-col">
               <div>UNISWAP V3 POOL</div>
-              <div className="text-sm">TOKENID #{tokenId}</div>
-              <div className="text-sm">FEE {fee / 10000}%</div>
+              <div className="text-sm">
+                <a
+                  href={`https://app.uniswap.org/pools/${tokenId}`}
+                  target="_blank"
+                >
+                  TOKENID #{tokenId}
+                </a>
+              </div>
             </div>
             <div className="flex flex-col items-start">
               {/* 수익률 */}
@@ -674,7 +680,7 @@ const LpPoolCardUniswapV3 = ({
                   <div className="text-green-500">{`+%${(
                     (apy * apyConstant) /
                     365
-                  ).toFixed(2)}`}</div>
+                  ).toFixed(4)}`}</div>
                 </>
               ) : (
                 <>
@@ -682,7 +688,7 @@ const LpPoolCardUniswapV3 = ({
                   <div className="text-red-500">{`+%${(
                     (apy * apyConstant) /
                     365
-                  ).toFixed(2)}`}</div>
+                  ).toFixed(4)}`}</div>
                 </>
               )}
 
@@ -747,12 +753,12 @@ const LpPoolCardUniswapV3 = ({
                 <div>
                   {/* {LPTokenName}: {_pairname} */}
                   {/* {LPTokenName} */}
-                  {`${Number(token0Amount).toFixed(6)} ${symbol0}`}
+                  {`${Number(token0Amount).toFixed(4)} ${symbol0}`}
                 </div>
                 <div className="m-sans-body-reveal">
                   {/* {LPTokenName}: {_pairname} */}
                   {/* {_pairname} */}
-                  {`${Number(token1Amount).toFixed(6)} ${symbol1}`}
+                  {`${Number(token1Amount).toFixed(4)} ${symbol1}`}
                 </div>
               </div>
               <div>
@@ -773,12 +779,12 @@ const LpPoolCardUniswapV3 = ({
                   <div>
                     {/* {LPTokenName}: {_pairname} */}
                     {/* {LPTokenName} */}
-                    {`${Number(uncollectedFees0).toFixed(6)} ${symbol0}`}
+                    {`${Number(uncollectedFees0).toFixed(4)} ${symbol0}`}
                   </div>
                   <div>
                     {/* {LPTokenName}: {_pairname} */}
                     {/* {_pairname} */}
-                    {`${Number(uncollectedFees1).toFixed(6)} ${symbol1}`}
+                    {`${Number(uncollectedFees1).toFixed(4)} ${symbol1}`}
                   </div>
                 </div>
                 <div>

--- a/frontend/src/components/LpPoolCardUniswapV3Optimism.jsx
+++ b/frontend/src/components/LpPoolCardUniswapV3Optimism.jsx
@@ -678,8 +678,14 @@ const LpPoolCardUniswapV3Optimism = ({
             {/* 카드이름 */}
             <div className="flex flex-col">
               <div>UNISWAP V3 POOL</div>
-              <div className="text-sm">TOKENID #{tokenId}</div>
-              <div className="text-sm">FEE {fee / 10000}%</div>
+              <div className="text-sm">
+                <a
+                  href={`https://app.uniswap.org/pools/${tokenId}?chain=optimism`}
+                  target="_blank"
+                >
+                  TOKENID #{tokenId}
+                </a>
+              </div>
             </div>
             <div className="flex flex-col items-start">
               {/* 수익률 */}
@@ -689,7 +695,7 @@ const LpPoolCardUniswapV3Optimism = ({
                   <div className="text-green-500">{`+%${(
                     (apy * apyConstant) /
                     365
-                  ).toFixed(2)}`}</div>
+                  ).toFixed(4)}`}</div>
                 </>
               ) : (
                 <>
@@ -697,7 +703,7 @@ const LpPoolCardUniswapV3Optimism = ({
                   <div className="text-red-500">{`+%${(
                     (apy * apyConstant) /
                     365
-                  ).toFixed(2)}`}</div>
+                  ).toFixed(4)}`}</div>
                 </>
               )}
 
@@ -762,12 +768,12 @@ const LpPoolCardUniswapV3Optimism = ({
                 <div>
                   {/* {LPTokenName}: {_pairname} */}
                   {/* {LPTokenName} */}
-                  {`${Number(token0Amount).toFixed(6)} ${symbol0}`}
+                  {`${Number(token0Amount).toFixed(4)} ${symbol0}`}
                 </div>
                 <div className="m-sans-body-reveal">
                   {/* {LPTokenName}: {_pairname} */}
                   {/* {_pairname} */}
-                  {`${Number(token1Amount).toFixed(6)} ${symbol1}`}
+                  {`${Number(token1Amount).toFixed(4)} ${symbol1}`}
                 </div>
               </div>
               <div>
@@ -788,12 +794,12 @@ const LpPoolCardUniswapV3Optimism = ({
                   <div>
                     {/* {LPTokenName}: {_pairname} */}
                     {/* {LPTokenName} */}
-                    {`${Number(uncollectedFees0).toFixed(6)} ${symbol0}`}
+                    {`${Number(uncollectedFees0).toFixed(4)} ${symbol0}`}
                   </div>
                   <div>
                     {/* {LPTokenName}: {_pairname} */}
                     {/* {_pairname} */}
-                    {`${Number(uncollectedFees1).toFixed(6)} ${symbol1}`}
+                    {`${Number(uncollectedFees1).toFixed(4)} ${symbol1}`}
                   </div>
                 </div>
                 <div>

--- a/frontend/src/components/LpPoolCardUniswapV3Polygon.jsx
+++ b/frontend/src/components/LpPoolCardUniswapV3Polygon.jsx
@@ -668,8 +668,14 @@ const LpPoolCardUniswapV3Polygon = ({
             {/* 카드이름 */}
             <div className="flex flex-col">
               <div>UNISWAP V3 POOL</div>
-              <div className="text-sm">TOKENID #{tokenId}</div>
-              <div className="text-sm">FEE {fee / 10000}%</div>
+              <div className="text-sm">
+                <a
+                  href={`https://app.uniswap.org/pools/${tokenId}?chain=polygon`}
+                  target="_blank"
+                >
+                  TOKENID #{tokenId}
+                </a>
+              </div>
             </div>
             <div className="flex flex-col items-start">
               {/* 수익률 */}
@@ -679,7 +685,7 @@ const LpPoolCardUniswapV3Polygon = ({
                   <div className="text-green-500">{`+%${(
                     (apy * apyConstant) /
                     365
-                  ).toFixed(2)}`}</div>
+                  ).toFixed(4)}`}</div>
                 </>
               ) : (
                 <>
@@ -687,7 +693,7 @@ const LpPoolCardUniswapV3Polygon = ({
                   <div className="text-red-500">{`+%${(
                     (apy * apyConstant) /
                     365
-                  ).toFixed(2)}`}</div>
+                  ).toFixed(4)}`}</div>
                 </>
               )}
 
@@ -752,12 +758,12 @@ const LpPoolCardUniswapV3Polygon = ({
                 <div>
                   {/* {LPTokenName}: {_pairname} */}
                   {/* {LPTokenName} */}
-                  {`${Number(token0Amount).toFixed(6)} ${symbol0}`}
+                  {`${Number(token0Amount).toFixed(4)} ${symbol0}`}
                 </div>
                 <div className="m-sans-body-reveal">
                   {/* {LPTokenName}: {_pairname} */}
                   {/* {_pairname} */}
-                  {`${Number(token1Amount).toFixed(6)} ${symbol1}`}
+                  {`${Number(token1Amount).toFixed(4)} ${symbol1}`}
                 </div>
               </div>
               <div>
@@ -778,12 +784,12 @@ const LpPoolCardUniswapV3Polygon = ({
                   <div>
                     {/* {LPTokenName}: {_pairname} */}
                     {/* {LPTokenName} */}
-                    {`${Number(uncollectedFees0).toFixed(6)} ${symbol0}`}
+                    {`${Number(uncollectedFees0).toFixed(4)} ${symbol0}`}
                   </div>
                   <div>
                     {/* {LPTokenName}: {_pairname} */}
                     {/* {_pairname} */}
-                    {`${Number(uncollectedFees1).toFixed(6)} ${symbol1}`}
+                    {`${Number(uncollectedFees1).toFixed(4)} ${symbol1}`}
                   </div>
                 </div>
                 <div>


### PR DESCRIPTION
## 개요
자릿수 4자리로 통일하고, 유니스왑 링크 추가했습니다.
## 변경사항에 대한 설명

## 팀 공유 및 요청 사항
유니스왑 링크 v3이더리움만 제대로 뜹니다. v3 폴리곤이나 아비트럼은 유니스왑 들어간 후 체인을 변경해주어야 뜨고, 
v2는 풀 자체 보여주는 링크는 없네요. 유동성 더하기 페이지는 있는데, 아직 추가는 안 했습니다! 고려해보시고 필요하시면 추가할게요!